### PR TITLE
Update versions of all packages, keeping Python at 3.6

### DIFF
--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -91,11 +91,8 @@ RUN pip install jupyterhub==0.8.1
 
 RUN pip install psycopg2==2.7.5
 
-# Installed in conda environment
-RUN jupyter serverextension enable --sys-prefix --py jupyterlab
-
 # Configure JuptyerLab to support widgets
-RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager
+RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.37
 
 #RUN pip install nbgrader==0.5.4
 RUN pip install git+git://github.com/berkeley-dsep-infra/nbgrader.git@7aba39a

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -66,7 +66,7 @@ USER jovyan
 # Download, install and configure the Conda environment
 
 RUN curl -o /tmp/miniconda.sh \
-	https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh
+	https://repo.continuum.io/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh
 
 # Install miniconda
 RUN bash /tmp/miniconda.sh -b -u -p ${CONDA_PREFIX}

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -94,6 +94,9 @@ RUN pip install psycopg2==2.7.5
 # Installed in conda environment
 RUN jupyter serverextension enable --sys-prefix --py jupyterlab
 
+# Configure JuptyerLab to support widgets
+RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager
+
 #RUN pip install nbgrader==0.5.4
 RUN pip install git+git://github.com/berkeley-dsep-infra/nbgrader.git@7aba39a
 RUN jupyter nbextension install --sys-prefix --py nbgrader

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -91,6 +91,11 @@ RUN pip install jupyterhub==0.8.1
 
 RUN pip install psycopg2==2.7.5
 
+# JupyterLab installation diagnostics
+RUN jupyter lab --version
+RUN jupyter lab path
+RUN which jupyter-lab
+
 # Configure JuptyerLab to support widgets
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.37
 

--- a/user-image/environment.yml
+++ b/user-image/environment.yml
@@ -38,6 +38,7 @@ dependencies:
   - nbconvert=5.3.1
   - nbformat=4.4.0
   - networkx=2.1
+  - nodejs=8.11.4
   - notebook=5.6.0
   - numpy=1.15.1
   - numpy-base=1.15.1

--- a/user-image/environment.yml
+++ b/user-image/environment.yml
@@ -1,88 +1,91 @@
 name: data100
 channels:
-- defaults
+  - defaults
 dependencies:
-- attrs=17.3.0
-- beautifulsoup4=4.6.0
-- bleach=2.1.2
-- chardet=3.0.4
-- coverage=4.4.2
-- cryptography=2.1.4
-- cycler=0.10.0
-- dask=0.16.1
-- decorator=4.2.1
-- entrypoints=0.2.3
-- expat=2.2.5
-- flake8=3.5.0
-- html5lib=1.0.1
-- hypothesis=3.38.5
-- ipykernel=4.7.0
-- ipython=6.2.1
-- ipython_genutils=0.2.0
-- ipywidgets=7.1.0
-- jedi=0.11.1
-- joblib=0.11
-- jsonschema=2.6.0
-- jupyter=1.0.0
-- jupyter_client=5.2.1
-- jupyter_console=5.2.0
-- jupyter_core=4.4.0
-- lxml=4.1.1
-- matplotlib=2.1.1
-- mistune=0.8.3
-- nbconvert=5.3.1
-- nbformat=4.4.0
-- networkx=2.0
-- notebook=5.4.1
-- numpy=1.12.1
-- pandas=0.22
-- pandoc=1.19.2.1
-- pandocfilters=1.4.2
-- patsy=0.5.0
-- pcre=8.41
-- pep8=1.7.1
-- pickleshare=0.7.4
-- pip=9.0.1
-- plotly=2.2.2
-- pluggy=0.6.0
-- prompt_toolkit=1.0.15
-- protobuf=3.4.1
-- py=1.5.2
-- pyflakes=1.5.0
-- pygments=2.2.0
-- pylint=1.8.1
-- pyparsing=2.2.0
-- pytest=3.3.2
-- python=3.6.4
-- python-dateutil=2.6.1
-- pytz=2017.3
-- pyzmq=16.0.3
-- requests=2.18.4
-- scikit-image=0.13.0
-- scikit-learn=0.19.1
-- scipy=1.0.0
-- seaborn=0.8.1
-- setuptools=38.4.0
-- simplegeneric=0.8.1
-- sip=4.18.1
-- six=1.11.0
-- sqlalchemy=1.2.1
-- sqlite=3.20.1
-- statsmodels=0.8.0
-- sympy=1.1.1
-- tensorflow=1.1.0
-- toolz=0.9.0
-- tornado=4.5.3
-- traitlets=4.3.2
-- widgetsnbextension=3.1.0
-- xarray=0.10.0
-- xz=5.2.3
-- zeromq=4.2.2
-- pip:
-  - colorlover==0.2.1
-  - cufflinks==0.12.1
-  - jupyterlab==0.31.12
-  - oauthlib==2.0.6
-  - requests-oauthlib==0.8.0
-  - tweepy==3.5.0
-  
+  - attrs=18.1.0
+  - beautifulsoup4=4.6.3
+  - bleach=2.1.4
+  - bokeh=0.13.0
+  - chardet=3.0.4
+  - coverage=4.5.1
+  - cloudpickle=0.5.5
+  - cryptography=2.3.1
+  - cycler=0.10.0
+  - cython=0.28.5
+  - cytoolz=0.9.0.1
+  - dask=0.19.0
+  - dask-core=0.19.0
+  - decorator=4.3.0
+  - distributed=1.23.0
+  - entrypoints=0.2.3
+  - expat=2.2.6
+  - flake8=3.5.0
+  - html5lib=1.0.1
+  - ipykernel=4.8.2
+  - ipython=6.5.0
+  - ipython_genutils=0.2.0
+  - ipywidgets=7.4.0
+  - jedi=0.12.1
+  - jinja2=2.10
+  - jsonschema=2.6.0
+  - jupyter=1.0.0
+  - jupyter_client=5.2.3
+  - jupyter_console=5.2.0
+  - jupyter_core=4.4.0
+  - markupsafe=1.0
+  - matplotlib=2.2.3
+  - mistune=0.8.3
+  - nbconvert=5.3.1
+  - nbformat=4.4.0
+  - networkx=2.1
+  - notebook=5.6.0
+  - numpy=1.15.1
+  - numpy-base=1.15.1
+  - pandas=0.23.4
+  - pandoc=2.2.3.2
+  - pandocfilters=1.4.2
+  - patsy=0.5.0
+  - pcre=8.42
+  - pickleshare=0.7.4
+  - pip=10.0.1
+  - plotly=3.1.1
+  - prompt_toolkit=1.0.15
+  - psutil=5.4.7
+  - ptyprocess=0.6.0
+  - py=1.5.4
+  - pygments=2.2.0
+  - pyparsing=2.2.0
+  - pytest=3.7.3
+  - python=3.6.6
+  - python-dateutil=2.7.3
+  - pytz=2018.5
+  - pyyaml=3.13
+  - pyzmq=17.1.2
+  - requests=2.19.1
+  - scikit-image=0.14.0
+  - scikit-learn=0.19.1
+  - scipy=1.1.0
+  - seaborn=0.9.0
+  - setuptools=40.2.0
+  - simplegeneric=0.8.1
+  - sip=4.19.12
+  - six=1.11.0
+  - sqlite=3.24.0
+  - statsmodels=0.9.0
+  - sympy=1.2
+  - terminado=0.8.1
+  - toolz=0.9.0
+  - tornado=5.1
+  - traitlets=4.3.2
+  - widgetsnbextension=3.4.0
+  - xarray=0.10.8
+  - xz=5.2.4
+  - zeromq=4.2.5
+  - pip:
+    - colorlover==0.2.1
+    - cufflinks==0.13.0
+    - jupyterlab==0.34.7
+    - jupyterlab-launcher==0.13.1
+    - oauthlib==2.1.0
+    - requests-oauthlib==1.0.0
+    - tweepy==3.6.0


### PR DESCRIPTION
This is a big update bringing all package versions to their current up to date state. Once it passes CI and goes into staging, we should have the team run some checks online with our actual codes before pushing to prod, as virtually every package changed versions.

I should have done this earlier in the summer - not ideal to be doing this now with the class running! But better now early in the semester, than stay locked in with old versions of quite a few packages for the whole term.